### PR TITLE
Refactoring agenda course to set explicitly group_numbers

### DIFF
--- a/app/models/academic_degree_term_course.rb
+++ b/app/models/academic_degree_term_course.rb
@@ -13,4 +13,8 @@ class AcademicDegreeTermCourse < ActiveRecord::Base
 
   default_scope { includes(:course).order("courses.code") }
   delegate :code, to: :course
+
+  def group_numbers
+    groups.map(&:number)
+  end
 end

--- a/app/models/agenda/course.rb
+++ b/app/models/agenda/course.rb
@@ -15,14 +15,11 @@ class Agenda::Course < ActiveRecord::Base
   scope :mandatory, -> { where(mandatory: true) }
   scope :optional, -> { where(mandatory: false) }
 
+  default :group_numbers, []
   default :mandatory, false
 
-  def groups
+  def academic_degree_term_course_groups
     academic_degree_term_course&.groups || []
-  end
-
-  def group_numbers
-    super || groups.map(&:number)
   end
 
   def group_numbers=(value)
@@ -33,14 +30,14 @@ class Agenda::Course < ActiveRecord::Base
     selected_groups.reject(&method(:overlaps_leaves?))
   end
 
+  def reset_group_numbers
+    self.group_numbers = academic_degree_term_course.group_numbers
+  end
+
   private
 
   def selected_groups
-    groups.select(&method(:selected?))
-  end
-
-  def selected?(group)
-    !agenda.filter_groups? || group.number.in?(group_numbers)
+    academic_degree_term_course_groups.select { |group| group.number.in?(group_numbers) }
   end
 
   def overlaps_leaves?(group)

--- a/app/views/agendas/group_selection.html.haml
+++ b/app/views/agendas/group_selection.html.haml
@@ -35,7 +35,7 @@
           %tbody
             - group_index = 0
             = course_fields.collection_check_boxes :group_numbers,
-              course_fields.object.groups, :number, :number do |group_fields|
+              course_fields.object.academic_degree_term_course_groups, :number, :number do |group_fields|
               - group_index += 1
               - group_fields.object.periods.each_with_index do |period, index|
                 %tr{ class: ("active" if group_index.odd?) }

--- a/app/views/schedules/_overview.html.haml
+++ b/app/views/schedules/_overview.html.haml
@@ -27,6 +27,5 @@
               %td
                 %span.label.label-default{ class: course_color_css_class(course_colors, course.code) }= course.code
               %td
-                - group_numbers = @agenda.filter_groups? ? course.group_numbers : course.groups.map(&:number)
-                - group_numbers.each do |group_number|
+                - course.group_numbers.each do |group_number|
                   %span.label.label-default{ class: course_color_css_class(course_colors, course.code) }= group_number

--- a/lib/schedule_generator_test_case.rb
+++ b/lib/schedule_generator_test_case.rb
@@ -11,6 +11,7 @@ class ScheduleGeneratorTestCase
   ).freeze
   AGENDA_COURSE_ATTRIBUTES = %w(
     academic_degree_term_course_id
+    group_numbers
     mandatory
   ).freeze
   COURSE_ATTRIBUTES = %w(

--- a/spec/controllers/agendas_controller_spec.rb
+++ b/spec/controllers/agendas_controller_spec.rb
@@ -286,7 +286,7 @@ describe AgendasController do
       end
 
       context "when the agenda was saved" do
-        let(:group_numbers) { Array(agenda.courses.first.groups.first.number) }
+        let(:group_numbers) { Array(agenda.courses.first.group_numbers.first) }
         before do
           put :update, params: {
             agenda: {

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -22,6 +22,7 @@ FactoryGirl.define do
       build_list(:agenda_course, 4).map do |course|
         course.academic_degree_term_course =
           build(:academic_degree_term_course, academic_degree_term: academic_degree_term)
+        course.reset_group_numbers
         course
       end
     end
@@ -44,6 +45,8 @@ FactoryGirl.define do
   end
 
   factory :agenda_course, class: "Agenda::Course" do
+    after(:build, &:reset_group_numbers)
+
     academic_degree_term_course
     agenda { Agenda.new }
 

--- a/spec/lib/schedule_generator_test_case_spec.rb
+++ b/spec/lib/schedule_generator_test_case_spec.rb
@@ -44,7 +44,7 @@ describe ScheduleGeneratorTestCase do
         {
           course_attributes: { code: course.code },
           id: course.academic_degree_term_course_id,
-          groups: course.groups,
+          groups: course.academic_degree_term_course.groups,
         }
       end
     end
@@ -52,6 +52,7 @@ describe ScheduleGeneratorTestCase do
       agenda.courses.map do |course|
         {
           academic_degree_term_course_id: course.academic_degree_term_course_id,
+          group_numbers: course.academic_degree_term_course.groups.map(&:number),
           mandatory: course.mandatory?,
         }
       end

--- a/spec/models/academic_degree_term_course_spec.rb
+++ b/spec/models/academic_degree_term_course_spec.rb
@@ -30,4 +30,13 @@ describe AcademicDegreeTermCourse do
       expect(described_class.all).to eq(default_scope)
     end
   end
+
+  describe "#group_numbers" do
+    subject(:academic_degree_term_course) { build(:academic_degree_term_course, groups: groups) }
+    let(:groups) { build_list(:group, 3) }
+
+    it "returns the numbers of all groups" do
+      expect(academic_degree_term_course.group_numbers).to eq(groups.map(&:number))
+    end
+  end
 end

--- a/spec/models/agenda/course_spec.rb
+++ b/spec/models/agenda/course_spec.rb
@@ -10,7 +10,7 @@ describe Agenda::Course do
       Group.new(number: 3, periods: [Period.new(starts_at: 500, ends_at: 600)]),
     ])
   end
-  let(:agenda) { build(:agenda, filter_groups: true, leaves: leaves) }
+  let(:agenda) { build(:agenda, leaves: leaves) }
   let(:leaves) do
     [
       Leave.new(starts_at: 0, ends_at: 100),
@@ -36,29 +36,8 @@ describe Agenda::Course do
 
   it { is_expected.to delegate_method(:code).to(:academic_degree_term_course) }
 
+  its(:group_numbers) { is_expected.to eq([]) }
   its(:mandatory) { is_expected.to eq(false) }
-
-  describe "#groups" do
-    context "when no academic_degree_term_course is provided" do
-      before { course.academic_degree_term_course = nil }
-      it { expect(course.groups).to eq([]) }
-    end
-
-    context "when an academic_degree_term_course is provided" do
-      it { expect(course.groups).to eq(academic_degree_term_course.groups) }
-    end
-  end
-
-  describe "#group_numbers" do
-    context "when explicitly set" do
-      before { course.group_numbers = [1, 2] }
-      it { expect(course.group_numbers).to eq([1, 2]) }
-    end
-
-    context "when not set" do
-      it { expect(course.group_numbers).to eq(academic_degree_term_course.groups.map(&:number)) }
-    end
-  end
 
   describe "scopes" do
     let!(:mandatory_courses) { create_list(:mandatory_agenda_course, 2) }
@@ -73,24 +52,38 @@ describe Agenda::Course do
     end
   end
 
+  describe "#academic_degree_term_course_groups" do
+    context "when there is no academic_degree_term_course" do
+      before { course.academic_degree_term_course = nil }
+
+      its(:academic_degree_term_course_groups) { is_expected.to eq([]) }
+    end
+
+    context "when there is an academic_degree_term_course" do
+      its(:academic_degree_term_course_groups) { is_expected.to eq(academic_degree_term_course.groups) }
+    end
+  end
+
+  describe "#group_numbers=" do
+    before { course.group_numbers = ["", "", 1, 3, 5, "", nil] }
+
+    specify { expect(course.group_numbers).to eq([1, 3, 5]) }
+  end
+
   describe "#pruned_groups" do
     before { course.group_numbers = [1, 2] }
 
-    context "when agenda does not filter groups" do
-      before { agenda.filter_groups = false }
-
-      it "returns groups that do not overlap with leaves" do
-        expect(course.pruned_groups).to eq([
-          Group.new(number: 1, periods: [Period.new(starts_at: 500, ends_at: 600)]),
-          Group.new(number: 3, periods: [Period.new(starts_at: 500, ends_at: 600)]),
-        ])
-      end
+    it "returns groups that do not overlap with leaves" do
+      expect(course.pruned_groups).to eq([Group.new(number: 1, periods: [Period.new(starts_at: 500, ends_at: 600)])])
     end
+  end
 
-    context "when agenda does filter groupes" do
-      it "returns groups that do not overlap with leaves and have been selected" do
-        expect(course.pruned_groups).to eq([Group.new(number: 1, periods: [Period.new(starts_at: 500, ends_at: 600)])])
-      end
+  describe "#reset_group_numbers" do
+    before { course.group_numbers = [] }
+
+    it "sets the group numbers to the ones of the academic_degree_term_course" do
+      expect { course.reset_group_numbers }
+        .to change { course.group_numbers }.to(academic_degree_term_course.group_numbers)
     end
   end
 end

--- a/spec/support/schedule_generator_test_cases/613cf10cae0339469e4a6c560fa35c23.yml
+++ b/spec/support/schedule_generator_test_cases/613cf10cae0339469e4a6c560fa35c23.yml
@@ -6,26 +6,50 @@
   :courses_attributes:
   - :academic_degree_term_course_id: 4415
     :mandatory: false
+    :group_numbers:
+    - 1
   - :academic_degree_term_course_id: 4423
     :mandatory: false
+    :group_numbers:
+    - 1
   - :academic_degree_term_course_id: 4427
     :mandatory: false
+    :group_numbers:
+    - 80
   - :academic_degree_term_course_id: 4430
     :mandatory: false
+    :group_numbers:
+    - 1
   - :academic_degree_term_course_id: 4432
     :mandatory: false
+    :group_numbers:
+    - 1
+    - 2
   - :academic_degree_term_course_id: 4435
     :mandatory: false
+    :group_numbers:
+    - 1
   - :academic_degree_term_course_id: 4437
     :mandatory: false
+    :group_numbers:
+    - 1
   - :academic_degree_term_course_id: 4438
     :mandatory: false
+    :group_numbers:
+    - 1
   - :academic_degree_term_course_id: 4441
     :mandatory: false
+    :group_numbers:
+    - 1
   - :academic_degree_term_course_id: 4442
     :mandatory: false
+    :group_numbers:
+    - 1
   - :academic_degree_term_course_id: 4449
     :mandatory: false
+    :group_numbers:
+    - 1
+    - 2
 :generated_course_groups:
 - - !ruby/object:CourseGroup
     code: ENT202

--- a/spec/support/schedule_generator_test_cases/6d44cb9f344acdcc583e333b5a354862.yml
+++ b/spec/support/schedule_generator_test_cases/6d44cb9f344acdcc583e333b5a354862.yml
@@ -9,16 +9,45 @@
   :courses_attributes:
   - :academic_degree_term_course_id: 3051
     :mandatory: true
+    :group_numbers:
+    - 1
+    - 2
   - :academic_degree_term_course_id: 3058
     :mandatory: false
+    :group_numbers:
+    - 1
+    - 2
   - :academic_degree_term_course_id: 3059
     :mandatory: true
+    :group_numbers:
+    - 1
   - :academic_degree_term_course_id: 3065
     :mandatory: false
+    :group_numbers:
+    - 1
+    - 2
   - :academic_degree_term_course_id: 3066
     :mandatory: true
+    :group_numbers:
+    - 1
+    - 2
   - :academic_degree_term_course_id: 3072
     :mandatory: false
+    :group_numbers:
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
+    - 6
+    - 7
+    - 8
+    - 9
+    - 10
+    - 11
+    - 12
+    - 13
+    - 14
 :generated_course_groups:
 - - !ruby/object:CourseGroup
     code: GTI619

--- a/spec/support/schedule_generator_test_cases/8188864d66f7ecbd58f4aa91eb85fcb6.yml
+++ b/spec/support/schedule_generator_test_cases/8188864d66f7ecbd58f4aa91eb85fcb6.yml
@@ -6,12 +6,23 @@
   :courses_attributes:
   - :academic_degree_term_course_id: 3065
     :mandatory: true
+    :group_numbers:
+    - 1
+    - 2
   - :academic_degree_term_course_id: 3066
     :mandatory: true
+    :group_numbers:
+    - 1
+    - 2
   - :academic_degree_term_course_id: 3067
     :mandatory: true
+    :group_numbers:
+    - 1
   - :academic_degree_term_course_id: 3068
     :mandatory: true
+    :group_numbers:
+    - 1
+    - 2
 :generated_course_groups:
 - - !ruby/object:CourseGroup
     code: LOG515

--- a/spec/support/schedule_generator_test_cases/87faf0ccc49f334f30f413b75aefa355.yml
+++ b/spec/support/schedule_generator_test_cases/87faf0ccc49f334f30f413b75aefa355.yml
@@ -12,14 +12,37 @@
   :courses_attributes:
   - :academic_degree_term_course_id: 3775
     :mandatory: false
+    :group_numbers:
+    - 1
+    - 2
+    - 3
+    - 4
   - :academic_degree_term_course_id: 3778
     :mandatory: false
+    :group_numbers:
+    - 1
+    - 2
+    - 3
   - :academic_degree_term_course_id: 3796
     :mandatory: false
+    :group_numbers:
+    - 1
+    - 4
+    - 9
   - :academic_degree_term_course_id: 3804
     :mandatory: false
+    :group_numbers:
+    - 2
+    - 5
+    - 6
+    - 7
   - :academic_degree_term_course_id: 3805
     :mandatory: false
+    :group_numbers:
+    - 1
+    - 3
+    - 4
+    - 8
 :generated_course_groups:
 - - !ruby/object:CourseGroup
     code: CTN404

--- a/spec/support/schedule_generator_test_cases/91a1963f3025962c5bf243cb8dc42639.yml
+++ b/spec/support/schedule_generator_test_cases/91a1963f3025962c5bf243cb8dc42639.yml
@@ -6,10 +6,20 @@
   :courses_attributes:
   - :academic_degree_term_course_id: 3051
     :mandatory: false
+    :group_numbers:
+    - 1
+    - 2
   - :academic_degree_term_course_id: 3052
     :mandatory: false
+    :group_numbers:
+    - 1
+    - 2
+    - 3
+    - 4
   - :academic_degree_term_course_id: 3055
     :mandatory: false
+    :group_numbers:
+    - 1
 :generated_course_groups:
 - - !ruby/object:CourseGroup
     code: LOG100

--- a/spec/support/schedule_generator_test_cases/a8c5cfd254957a91fee1e3a9b1e482ae.yml
+++ b/spec/support/schedule_generator_test_cases/a8c5cfd254957a91fee1e3a9b1e482ae.yml
@@ -6,12 +6,23 @@
   :courses_attributes:
   - :academic_degree_term_course_id: 3065
     :mandatory: false
+    :group_numbers:
+    - 1
+    - 2
   - :academic_degree_term_course_id: 3066
     :mandatory: false
+    :group_numbers:
+    - 1
+    - 2
   - :academic_degree_term_course_id: 3067
     :mandatory: false
+    :group_numbers:
+    - 1
   - :academic_degree_term_course_id: 3068
     :mandatory: false
+    :group_numbers:
+    - 1
+    - 2
 :generated_course_groups:
 - - !ruby/object:CourseGroup
     code: LOG515

--- a/spec/support/schedule_generator_test_cases/cf051c4139b24dd685aa26525292aea9.yml
+++ b/spec/support/schedule_generator_test_cases/cf051c4139b24dd685aa26525292aea9.yml
@@ -9,8 +9,35 @@
   :courses_attributes:
   - :academic_degree_term_course_id: 4208
     :mandatory: false
+    :group_numbers:
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
+    - 6
+    - 7
+    - 8
+    - 9
+    - 10
+    - 11
+    - 12
+    - 13
   - :academic_degree_term_course_id: 4216
     :mandatory: false
+    :group_numbers:
+    - 1
+    - 2
+    - 3
+    - 4
+    - 6
+    - 7
+    - 8
+    - 9
+    - 10
+    - 11
+    - 13
+    - 14
 :generated_course_groups:
 - - !ruby/object:CourseGroup
     code: CHM131


### PR DESCRIPTION
Dependant on backfill of previous `Agenda::Course` in the database (i.e. they now need to have their `group_numbers` populated explictly)