### PR TITLE
Fix erreurs de build dans CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,10 @@ jobs:
     docker:
       - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
     steps:
-      #Add node_modules to path
-      - run: export "PATH=$PATH:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
+      - run:
+          name: Add node_modules to PATH
+          command: |
+            echo 'export PATH=$PATH:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin:$PATH' >> $BASH_ENV
       # Machine Setup
       #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
       # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ jobs:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
       CODECOV_TOKEN: 7fb93589-618d-41f0-a5b6-e5fdb4c78e55
-      PATH: ${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin
       RACK_ENV: test
       RAILS_ENV: test
     # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
@@ -33,6 +32,8 @@ jobs:
     docker:
       - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
     steps:
+      #Add node_modules to path
+      - run: export "PATH=$PATH:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
       # Machine Setup
       #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
       # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.


### PR DESCRIPTION
J'ai remarqué que depuis l'upgrade à Circle 2.0, les builds échouent à cause de l'erreur: `mkdir not found`.

Selon [ce issue](https://discuss.circleci.com/t/bin-sh-mkdir-command-not-found/8710/14) la définition du PATH n'accepte plus l'interpolation de variables. Avec la config courante, la variable PATH devient litéralement `${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin `et donc `mkdir` n'est pas trouvé.

J'ai donc ajouté une étape pour ajouter le chemin à PATH manuellement.